### PR TITLE
Fix broken "Awesomeness" org. structure

### DIFF
--- a/FRD.md
+++ b/FRD.md
@@ -14,7 +14,7 @@ is supposed to do, that aren't really a "functional" need.
 ### Awesomeness
 
 1.  ADE should be:
-  1. super fast,
-  2. "Web scale",
-  3. cloud-enabled, and
-  4. 100% artisanally buzzword-compliant.
+    1. super fast,
+    2. "Web scale",
+    3. cloud-enabled, and
+    4. 100% artisanally buzzword-compliant.


### PR DESCRIPTION
The Markdown syntax was invalid, using 2 spaces instead of the required 4 to indent sub-bullets.  This caused the Github formatter to become confused and think that the "Awesomeness" requirements were not supposed to be nested.  These *are* supposed to be nested though, so fix this by fixing the spaces.

Fixes Issue #2